### PR TITLE
Bewertet Version

### DIFF
--- a/ModSim WS1718 Uebung 03.ipynb
+++ b/ModSim WS1718 Uebung 03.ipynb
@@ -180,7 +180,7 @@
    "source": [
     "### Erklärung\n",
     "\n",
-    "Durch die 64bit-double-precision-Floating-Point-Zahlen können Dezimalzahlen nicht genau dargestellt werden, da die Zahlen durch Bruchteile berechnet und dargestellt werden. Daher ist (1.3-1.0) nicht genau 0.3. Der Wahrheitswert der Aussage ist also False."
+    "Durch die 64bit-double-precision-Floating-Point-Zahlen können Dezimalzahlen nicht genau dargestellt werden, da die Zahlen durch Bruchteile berechnet und dargestellt werden. Daher ist (1.3-1.0) nicht genau 0.3. Der Wahrheitswert der Aussage ist also False.#"
    ]
   },
   {


### PR DESCRIPTION
Af3. Nachkommastellen wird nicht durch Bruchteile berechnet, sondern durch Binär dargestellt und berechnet. (-5)